### PR TITLE
Fix overrun of Field_Tiles array

### DIFF
--- a/Source/game.c
+++ b/Source/game.c
@@ -173,7 +173,7 @@ void ai_tick(float delta)
 
                 if (farmer->searchState.searchTimer <= 0.0f)
                 {
-                    uint32_t tileIndex = rand_range(0U, Field_Width * Field_Height);
+                    uint32_t tileIndex = rand_range(0U, Field_Width * Field_Height - 1);
                     Field_Tile* tile = &Field_Tiles[tileIndex];
 
                     if (tile->stage != FieldStage_Planted)


### PR DESCRIPTION
Random tile search used rand_range(0, w*h) to pick a random tile, but since rand() is inclusive of RAND_MAX, this can result in the invalid index of w*h. Since it's expected, particularly in the case of rand_rangef(0.f, 1.f) that both endpoints are included, the rand_range is now (0, w*h - 1).